### PR TITLE
fix(rust): preserve ACP flags in effective_agent_command fallback

### DIFF
--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -117,12 +117,19 @@ pub fn resolve_path(value: &str) -> Result<String, ConfigError> {
 }
 
 /// Get the effective agent launch command.
-/// Prefers agent.command if non-default, otherwise falls back to copilot.command.
-pub fn effective_agent_command(config: &RustyConfig) -> &str {
+/// Prefers agent.command if non-default, otherwise falls back to copilot.command
+/// with --acp --stdio flags appended (required for ACP protocol communication).
+pub fn effective_agent_command(config: &RustyConfig) -> String {
     if config.agent.command != "copilot --acp --stdio" && !config.agent.command.is_empty() {
-        &config.agent.command
+        config.agent.command.clone()
     } else {
-        &config.copilot.command
+        // Fallback to copilot.command but ensure --acp --stdio flags are present
+        let base = &config.copilot.command;
+        if base.contains("--acp") && base.contains("--stdio") {
+            base.clone()
+        } else {
+            format!("{base} --acp --stdio")
+        }
     }
 }
 

--- a/rust/tests/config_test.rs
+++ b/rust/tests/config_test.rs
@@ -404,8 +404,23 @@ fn effective_agent_command_prefers_agent_command_and_falls_back_to_copilot_comma
     let mut config = RustyConfig::default();
     config.copilot.command = "copilot-cli".to_string();
 
-    assert_eq!(effective_agent_command(&config), "copilot-cli");
+    // Fallback should include --acp --stdio flags
+    let cmd = effective_agent_command(&config);
+    assert!(
+        cmd.contains("--acp") && cmd.contains("--stdio"),
+        "fallback command must include ACP flags, got: {cmd}"
+    );
 
     config.agent.command = "custom-agent --stdio".to_string();
     assert_eq!(effective_agent_command(&config), "custom-agent --stdio");
+}
+
+#[test]
+fn effective_agent_command_default_config_includes_acp_flags() {
+    let config = RustyConfig::default();
+    let cmd = effective_agent_command(&config);
+    assert!(
+        cmd.contains("--acp") && cmd.contains("--stdio"),
+        "default effective command must include --acp --stdio, got: {cmd}"
+    );
 }


### PR DESCRIPTION
Fixes PR #37 post-merge review: effective_agent_command() appends --acp --stdio when falling back to copilot.command. TDD with failing test.