### PR TITLE
chore(rust): add .editorconfig for consistent formatting

### DIFF
--- a/rust/.editorconfig
+++ b/rust/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig for Rust projects
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.toml]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
Add \.editorconfig\ to \ust/\ directory with standard Rust formatting settings:
- 4-space indentation for \.rs\ files
- UTF-8 charset
- LF line endings
- Trailing whitespace trimming
- Final newline insertion
- TOML: 2-space indent
- Makefile: tab indent

Closes #53