### PR TITLE
docs(rust): add build status badge to README

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -1,5 +1,7 @@
 # Rusty — Symphony for GitHub
 
+[![Build Status](https://github.com/ridermw/rusty/actions/workflows/make-all.yml/badge.svg)](https://github.com/ridermw/rusty/actions/workflows/make-all.yml)
+
 A Rust implementation of [Symphony](../SPEC.md) that orchestrates coding agents against GitHub Issues using Copilot CLI.
 
 > [!WARNING]


### PR DESCRIPTION
Add a GitHub Actions build-status badge for the \make-all\ workflow to the top of \ust/README.md\.

Closes #52