### PR TITLE
feat(rust): tracker reads GitHub Project status instead of labels

### DIFF
--- a/rust/WORKFLOW.md
+++ b/rust/WORKFLOW.md
@@ -3,6 +3,7 @@ tracker:
   kind: github
   owner: "ridermw"
   repo: "rusty"
+  project_number: 5
   active_issue_labels:
     - "Todo"
     - "InProgress"

--- a/rust/src/config/schema.rs
+++ b/rust/src/config/schema.rs
@@ -24,13 +24,14 @@ pub struct TrackerConfig {
     pub owner: Option<String>,
     /// Repository name or "owner/repo" combined format.
     pub repo: Option<String>,
+    /// GitHub Project number (e.g., 5). When set, uses project status for state tracking.
+    pub project_number: Option<u32>,
     pub active_states: Vec<String>,
     pub terminal_states: Vec<String>,
     pub labels: Vec<String>,
-    /// Labels that map to active issue states (e.g., ["todo", "in_progress"]).
-    /// Used when `active_states` needs label-based matching.
+    /// Labels that map to active issue states (fallback when project not enabled).
     pub active_issue_labels: Vec<String>,
-    /// Labels that map to terminal issue states (e.g., ["done", "closed"]).
+    /// Labels that map to terminal issue states (fallback when project not enabled).
     pub terminal_issue_labels: Vec<String>,
     pub state_labels: HashMap<String, String>,
     pub assignee: Option<String>,
@@ -79,6 +80,7 @@ impl Default for TrackerConfig {
             api_key: None,
             owner: None,
             repo: None,
+            project_number: None,
             active_states: vec!["open".to_string()],
             terminal_states: vec!["closed".to_string()],
             labels: Vec::new(),

--- a/rust/src/tracker/github/adapter.rs
+++ b/rust/src/tracker/github/adapter.rs
@@ -16,6 +16,135 @@ impl GitHubAdapter {
             config,
         }
     }
+
+    /// Check if project-based tracking is enabled and configured.
+    fn project_enabled(&self) -> bool {
+        self.config.project_number.unwrap_or(0) > 0
+    }
+
+    /// Fetch issues from the GitHub Project, using project status as the state.
+    /// Falls back to label-based filtering if project is not configured.
+    async fn fetch_project_items(
+        &self,
+        active_states: &[String],
+    ) -> Result<Vec<Issue>, TrackerError> {
+        let owner = self
+            .config
+            .owner
+            .as_deref()
+            .ok_or(TrackerError::MissingRepo)?;
+        let project_number = self.config.project_number.unwrap_or(0);
+
+        let output = tokio::process::Command::new("gh")
+            .args([
+                "project",
+                "item-list",
+                &project_number.to_string(),
+                "--owner",
+                owner,
+                "--format",
+                "json",
+                "--limit",
+                "100",
+            ])
+            .output()
+            .await
+            .map_err(|e| TrackerError::ApiRequest(format!("gh project item-list failed: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(TrackerError::ApiRequest(format!(
+                "gh project item-list returned {}: {stderr}",
+                output.status
+            )));
+        }
+
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .map_err(|e| TrackerError::UnknownPayload(format!("project JSON parse error: {e}")))?;
+
+        let items = json
+            .get("items")
+            .and_then(|i| i.as_array())
+            .ok_or_else(|| {
+                TrackerError::UnknownPayload("no items array in project response".into())
+            })?;
+
+        let active_lower: Vec<String> = active_states.iter().map(|s| s.to_lowercase()).collect();
+        let repo_name = self.config.repo.as_deref().unwrap_or("repo");
+
+        let mut issues = Vec::new();
+        for item in items {
+            let status = item.get("status").and_then(|s| s.as_str()).unwrap_or("");
+            let content = item.get("content");
+            let item_type = content
+                .and_then(|c| c.get("type"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("");
+
+            // Only process Issues (not PRs or drafts)
+            if item_type != "Issue" {
+                continue;
+            }
+
+            // Filter by active project states
+            if !active_lower.contains(&status.to_lowercase()) {
+                continue;
+            }
+
+            let number = content
+                .and_then(|c| c.get("number"))
+                .and_then(|n| n.as_u64())
+                .unwrap_or(0);
+            let title = content
+                .and_then(|c| c.get("title"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("")
+                .to_string();
+            let body = content
+                .and_then(|c| c.get("body"))
+                .and_then(|b| b.as_str())
+                .map(|s| s.to_string());
+            let url = content
+                .and_then(|c| c.get("url"))
+                .and_then(|u| u.as_str())
+                .map(|s| s.to_string());
+
+            let labels: Vec<String> = item
+                .get("labels")
+                .and_then(|l| l.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str())
+                        .map(|s| s.to_lowercase())
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            if number == 0 {
+                continue;
+            }
+
+            issues.push(Issue {
+                id: number.to_string(),
+                identifier: format!("{repo_name}-{number}"),
+                title,
+                description: body,
+                priority: labels.iter().find_map(|l| {
+                    l.strip_prefix("priority-")
+                        .and_then(|n| n.parse::<i32>().ok())
+                }),
+                state: status.to_string(), // Use project status as state
+                branch_name: None,
+                url,
+                labels,
+                blocked_by: vec![],
+                created_at: None,
+                updated_at: None,
+            });
+        }
+
+        Ok(issues)
+    }
 }
 
 #[async_trait]
@@ -24,9 +153,13 @@ impl Tracker for GitHubAdapter {
         &self,
         config: &TrackerConfig,
     ) -> Result<Vec<Issue>, TrackerError> {
-        // GitHub's labels query param uses AND semantics (issue must have ALL labels).
-        // For active_issue_labels we need OR semantics (issue has ANY of the labels).
-        // So fetch all open issues and post-filter for OR matching.
+        // If project is enabled, use project status for state tracking
+        if self.project_enabled() {
+            let active_states = config.effective_active_states();
+            return self.fetch_project_items(&active_states).await;
+        }
+
+        // Fallback: label-based filtering
         if !config.active_issue_labels.is_empty() {
             let all = self.client.fetch_issues(config, "open", None).await?;
             let required: Vec<String> = config
@@ -54,8 +187,87 @@ impl Tracker for GitHubAdapter {
     }
 
     async fn fetch_issue_states_by_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError> {
-        let numbers: Vec<u64> = ids.iter().filter_map(|id| id.parse::<u64>().ok()).collect();
+        if self.project_enabled() {
+            // For reconciliation, get project status for these specific issues
+            let all_states = self
+                .fetch_project_items(&[]) // fetch all statuses
+                .await
+                .unwrap_or_default();
 
+            // Filter all project items, not just active ones
+            let owner = self.config.owner.as_deref().unwrap_or("");
+            let project_number = self.config.project_number.unwrap_or(0);
+
+            // Re-fetch without state filter for reconciliation
+            let output = tokio::process::Command::new("gh")
+                .args([
+                    "project",
+                    "item-list",
+                    &project_number.to_string(),
+                    "--owner",
+                    owner,
+                    "--format",
+                    "json",
+                    "--limit",
+                    "100",
+                ])
+                .output()
+                .await
+                .map_err(|e| TrackerError::ApiRequest(format!("gh project failed: {e}")))?;
+
+            if !output.status.success() {
+                return Err(TrackerError::ApiRequest(
+                    "gh project item-list failed".into(),
+                ));
+            }
+
+            let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+                .map_err(|e| TrackerError::UnknownPayload(e.to_string()))?;
+
+            let repo_name = self.config.repo.as_deref().unwrap_or("repo");
+            let items = json.get("items").and_then(|i| i.as_array());
+
+            let mut results = Vec::new();
+            for id in ids {
+                if let Some(items) = items {
+                    if let Some(item) = items.iter().find(|i| {
+                        i.get("content")
+                            .and_then(|c| c.get("number"))
+                            .and_then(|n| n.as_u64())
+                            .map(|n| n.to_string())
+                            == Some(id.clone())
+                    }) {
+                        let status = item
+                            .get("status")
+                            .and_then(|s| s.as_str())
+                            .unwrap_or("open");
+                        let number: u64 = id.parse().unwrap_or(0);
+                        results.push(Issue {
+                            id: id.clone(),
+                            identifier: format!("{repo_name}-{number}"),
+                            title: item
+                                .get("title")
+                                .and_then(|t| t.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            description: None,
+                            priority: None,
+                            state: status.to_string(),
+                            branch_name: None,
+                            url: None,
+                            labels: vec![],
+                            blocked_by: vec![],
+                            created_at: None,
+                            updated_at: None,
+                        });
+                    }
+                }
+            }
+            return Ok(results);
+        }
+
+        // Fallback: REST API
+        let numbers: Vec<u64> = ids.iter().filter_map(|id| id.parse::<u64>().ok()).collect();
         self.client
             .fetch_issues_by_numbers(&self.config, &numbers)
             .await
@@ -66,6 +278,11 @@ impl Tracker for GitHubAdapter {
         states: &[String],
         config: &TrackerConfig,
     ) -> Result<Vec<Issue>, TrackerError> {
+        if self.project_enabled() {
+            return self.fetch_project_items(states).await;
+        }
+
+        // Fallback: REST API
         let github_state = if states
             .iter()
             .any(|state| state.eq_ignore_ascii_case("closed"))
@@ -76,9 +293,6 @@ impl Tracker for GitHubAdapter {
         };
 
         let all = self.client.fetch_issues(config, github_state, None).await?;
-
-        // Post-filter to only include issues whose resolved state matches the
-        // exact requested states (not the entire open/closed bucket).
         let requested: Vec<String> = states.iter().map(|s| s.to_lowercase()).collect();
         Ok(all
             .into_iter()


### PR DESCRIPTION
When tracker.project_number is set, Rusty uses the Project v2 status field for issue state tracking instead of labels. Queries via gh project item-list. Falls back to label-based filtering when project not configured. Fixes the disconnect between labels and project board.