### PR TITLE
fix(rust): resolve env var references in workspace.root

### DIFF
--- a/rust/WORKFLOW.md
+++ b/rust/WORKFLOW.md
@@ -36,7 +36,7 @@ tracker:
 polling:
   interval_ms: 5000
 workspace:
-  root: ~/code/rusty_workspaces
+  root: $RUSTY_WORKSPACE_ROOT
 hooks:
   after_create: |
     git clone --depth 1 https://github.com/ridermw/rusty .

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -86,7 +86,12 @@ pub fn resolve_workspace_root(config: &crate::config::schema::RustyConfig) -> Pa
         .workspace
         .root
         .as_deref()
-        .map(crate::config::expand_home)
+        .map(|root| {
+            // Resolve $VAR env references first, then expand ~
+            let resolved =
+                crate::config::resolve_env_value(root).unwrap_or_else(|_| root.to_string());
+            crate::config::expand_home(&resolved)
+        })
         .map(PathBuf::from)
         .unwrap_or_else(|| std::env::temp_dir().join("rusty_workspaces"))
 }


### PR DESCRIPTION
workspace.root now supports \ env references. Set \ to use a custom path (e.g., Q: drive).