### PR TITLE
feat(rust): parse Copilot log files for token usage metrics

### DIFF
--- a/rust/src/agent/log_parser.rs
+++ b/rust/src/agent/log_parser.rs
@@ -1,0 +1,296 @@
+//! Parse Copilot CLI log files for token usage metrics.
+//!
+//! Copilot CLI 1.0.5 does not expose token usage over the ACP protocol.
+//! When `agent.log_dir` is configured, Rusty passes `--log-dir <path>` to
+//! the Copilot CLI process and parses the resulting log files for
+//! `prompt_tokens_count`, `completion_tokens_count`, and `total_tokens_count`
+//! entries.
+
+use std::path::Path;
+
+use tokio::io::AsyncBufReadExt;
+use tracing::{debug, warn};
+
+/// Token counts extracted from a single log event.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LogTokenUsage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+}
+
+/// Parse a single line of Copilot log output for a token-count field.
+///
+/// Recognized patterns (colon-separated key-value):
+/// - `prompt_tokens_count: 45760`
+/// - `completion_tokens_count: 658`
+/// - `total_tokens_count: 46418`
+///
+/// Also handles JSON-embedded variants where the key-value appears inside
+/// a larger JSON object string, e.g. `"prompt_tokens_count":45760`.
+///
+/// Returns `Some((field, value))` if a recognized token field is found.
+pub fn parse_token_line(line: &str) -> Option<(&'static str, u64)> {
+    const FIELDS: &[(&str, &str)] = &[
+        ("prompt_tokens_count", "prompt"),
+        ("completion_tokens_count", "completion"),
+        ("total_tokens_count", "total"),
+    ];
+
+    for &(key, label) in FIELDS {
+        if let Some(value) = extract_value(line, key) {
+            return Some((label, value));
+        }
+    }
+    None
+}
+
+/// Extract a u64 value for a given key from a log line.
+/// Handles both `key: value` (plain) and `"key":value` / `"key": value` (JSON) formats.
+fn extract_value(line: &str, key: &str) -> Option<u64> {
+    // Try plain format: `key: 12345` or `key:12345`
+    if let Some(pos) = line.find(key) {
+        let after_key = &line[pos + key.len()..];
+        // Skip optional `"`, then expect `:`
+        let rest = after_key.trim_start_matches('"');
+        if let Some(rest) = rest.strip_prefix(':') {
+            let rest = rest.trim_start();
+            // Parse digits, stopping at non-digit
+            let num_str: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if !num_str.is_empty() {
+                return num_str.parse::<u64>().ok();
+            }
+        }
+    }
+    None
+}
+
+/// Scan all lines of a log file and accumulate the highest token counts seen.
+///
+/// Copilot logs may contain multiple usage snapshots; we take the maximum
+/// of each field since token counts are cumulative within a session.
+pub async fn scan_log_file(path: &Path) -> std::io::Result<LogTokenUsage> {
+    let file = tokio::fs::File::open(path).await?;
+    let reader = tokio::io::BufReader::new(file);
+    let mut lines = reader.lines();
+    let mut usage = LogTokenUsage::default();
+
+    while let Some(line) = lines.next_line().await? {
+        if let Some((field, value)) = parse_token_line(&line) {
+            match field {
+                "prompt" => {
+                    if value > usage.prompt_tokens {
+                        usage.prompt_tokens = value;
+                    }
+                }
+                "completion" => {
+                    if value > usage.completion_tokens {
+                        usage.completion_tokens = value;
+                    }
+                }
+                "total" => {
+                    if value > usage.total_tokens {
+                        usage.total_tokens = value;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(usage)
+}
+
+/// Scan all `process-*.log` files in a directory and return the aggregate
+/// maximum token usage across all files.
+pub async fn scan_log_dir(dir: &Path) -> LogTokenUsage {
+    let mut aggregate = LogTokenUsage::default();
+
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(entries) => entries,
+        Err(e) => {
+            warn!(dir = %dir.display(), error = %e, "failed to read log directory");
+            return aggregate;
+        }
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+
+        // Copilot writes logs to files like `process-*.log` or other .log files
+        if !name.ends_with(".log") {
+            continue;
+        }
+
+        match scan_log_file(&path).await {
+            Ok(usage) => {
+                debug!(
+                    file = %name,
+                    prompt = usage.prompt_tokens,
+                    completion = usage.completion_tokens,
+                    total = usage.total_tokens,
+                    "parsed log file"
+                );
+                aggregate.prompt_tokens = aggregate.prompt_tokens.max(usage.prompt_tokens);
+                aggregate.completion_tokens =
+                    aggregate.completion_tokens.max(usage.completion_tokens);
+                aggregate.total_tokens = aggregate.total_tokens.max(usage.total_tokens);
+            }
+            Err(e) => {
+                warn!(file = %name, error = %e, "failed to parse log file");
+            }
+        }
+    }
+
+    aggregate
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_token_line ──────────────────────────────────────────
+
+    #[test]
+    fn parse_plain_prompt_tokens() {
+        let line = "prompt_tokens_count: 45760";
+        assert_eq!(parse_token_line(line), Some(("prompt", 45760)));
+    }
+
+    #[test]
+    fn parse_plain_completion_tokens() {
+        let line = "completion_tokens_count: 658";
+        assert_eq!(parse_token_line(line), Some(("completion", 658)));
+    }
+
+    #[test]
+    fn parse_plain_total_tokens() {
+        let line = "total_tokens_count: 46418";
+        assert_eq!(parse_token_line(line), Some(("total", 46418)));
+    }
+
+    #[test]
+    fn parse_json_embedded_tokens() {
+        let line = r#"{"level":"info","prompt_tokens_count":12345,"ts":"2026-01-01"}"#;
+        assert_eq!(parse_token_line(line), Some(("prompt", 12345)));
+    }
+
+    #[test]
+    fn parse_json_with_spaces() {
+        let line = r#"  "total_tokens_count": 99999,"#;
+        assert_eq!(parse_token_line(line), Some(("total", 99999)));
+    }
+
+    #[test]
+    fn parse_no_match_returns_none() {
+        assert_eq!(parse_token_line("some other log line"), None);
+        assert_eq!(parse_token_line("tokens_count: 100"), None);
+        assert_eq!(parse_token_line(""), None);
+    }
+
+    #[test]
+    fn parse_zero_value() {
+        assert_eq!(
+            parse_token_line("prompt_tokens_count: 0"),
+            Some(("prompt", 0))
+        );
+    }
+
+    #[test]
+    fn parse_large_value() {
+        assert_eq!(
+            parse_token_line("total_tokens_count: 999999999"),
+            Some(("total", 999999999))
+        );
+    }
+
+    #[test]
+    fn parse_value_with_trailing_text() {
+        let line = "prompt_tokens_count: 500 (some note)";
+        assert_eq!(parse_token_line(line), Some(("prompt", 500)));
+    }
+
+    #[test]
+    fn parse_line_with_prefix_context() {
+        let line = "2026-03-14T09:00:00Z INFO assistant_usage prompt_tokens_count: 45760";
+        assert_eq!(parse_token_line(line), Some(("prompt", 45760)));
+    }
+
+    // ── scan_log_file ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn scan_log_file_extracts_max_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("process-1.log");
+        tokio::fs::write(
+            &log_path,
+            "\
+2026-03-14 INFO starting session
+prompt_tokens_count: 1000
+completion_tokens_count: 100
+total_tokens_count: 1100
+prompt_tokens_count: 2000
+completion_tokens_count: 200
+total_tokens_count: 2200
+",
+        )
+        .await
+        .unwrap();
+
+        let usage = scan_log_file(&log_path).await.unwrap();
+        assert_eq!(usage.prompt_tokens, 2000);
+        assert_eq!(usage.completion_tokens, 200);
+        assert_eq!(usage.total_tokens, 2200);
+    }
+
+    #[tokio::test]
+    async fn scan_log_file_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("empty.log");
+        tokio::fs::write(&log_path, "").await.unwrap();
+
+        let usage = scan_log_file(&log_path).await.unwrap();
+        assert_eq!(usage, LogTokenUsage::default());
+    }
+
+    // ── scan_log_dir ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn scan_log_dir_aggregates_across_files() {
+        let dir = tempfile::tempdir().unwrap();
+
+        tokio::fs::write(
+            dir.path().join("process-1.log"),
+            "prompt_tokens_count: 1000\ncompletion_tokens_count: 100\ntotal_tokens_count: 1100\n",
+        )
+        .await
+        .unwrap();
+
+        tokio::fs::write(
+            dir.path().join("process-2.log"),
+            "prompt_tokens_count: 3000\ncompletion_tokens_count: 50\ntotal_tokens_count: 3050\n",
+        )
+        .await
+        .unwrap();
+
+        // Non-log file should be ignored
+        tokio::fs::write(dir.path().join("other.txt"), "prompt_tokens_count: 99999\n")
+            .await
+            .unwrap();
+
+        let usage = scan_log_dir(dir.path()).await;
+        assert_eq!(usage.prompt_tokens, 3000);
+        assert_eq!(usage.completion_tokens, 100);
+        assert_eq!(usage.total_tokens, 3050);
+    }
+
+    #[tokio::test]
+    async fn scan_log_dir_missing_directory() {
+        let usage = scan_log_dir(Path::new("/nonexistent/path/xyz")).await;
+        assert_eq!(usage, LogTokenUsage::default());
+    }
+}

--- a/rust/src/agent/mod.rs
+++ b/rust/src/agent/mod.rs
@@ -1,5 +1,6 @@
 pub mod acp_client;
 pub mod dynamic_tool;
+pub mod log_parser;
 
 pub use acp_client::{
     AcpClient, AgentError, AgentEvent, ChildGuard, JsonRpcMessage, JsonRpcResponse, TurnResult,
@@ -142,7 +143,7 @@ pub async fn run_agent_attempt(
 
         let launch_cmd = crate::config::agent_launch_command(&config);
         let command_parts: Vec<&str> = launch_cmd.split_whitespace().collect();
-        let (cmd, args): (&str, &[&str]) = match command_parts.split_first() {
+        let (cmd, base_args): (&str, &[&str]) = match command_parts.split_first() {
             Some((cmd, args)) => (*cmd, args),
             None => {
                 warn!("agent.command is empty, falling back to copilot --acp");
@@ -150,7 +151,29 @@ pub async fn run_agent_attempt(
             }
         };
 
-        let mut client = match AcpClient::launch(cmd, args, &ws_path) {
+        // When log_dir is configured, create a per-session subdirectory and
+        // inject `--log-dir <path>` into the agent command so Copilot CLI
+        // writes its internal logs there. We parse those logs post-session
+        // to extract token usage metrics not available over ACP.
+        let session_log_dir = config.agent.log_dir.as_ref().map(|base| {
+            let session_stamp = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
+            let dir = std::path::PathBuf::from(base)
+                .join(format!("{}-{}", issue.identifier, session_stamp));
+            if let Err(e) = std::fs::create_dir_all(&dir) {
+                warn!(dir = %dir.display(), error = %e, "failed to create agent log directory");
+            }
+            dir
+        });
+
+        let mut owned_args: Vec<String> = base_args.iter().map(|s| s.to_string()).collect();
+        if let Some(ref log_dir) = session_log_dir {
+            owned_args.push("--log-dir".to_string());
+            owned_args.push(log_dir.to_string_lossy().to_string());
+            info!(log_dir = %log_dir.display(), "injecting --log-dir for token metrics");
+        }
+        let final_args: Vec<&str> = owned_args.iter().map(|s| s.as_str()).collect();
+
+        let mut client = match AcpClient::launch(cmd, &final_args, &ws_path) {
             Ok(client) => client,
             Err(e) => {
                 let error_message = format!("agent launch: {e}");
@@ -289,6 +312,7 @@ pub async fn run_agent_attempt(
                     let error_message = format!("turn failed: {reason}");
                     error!(%turn_id, %reason, "turn failed");
                     let _ = client.stop().await;
+                    emit_log_token_usage(&session_log_dir, &update_tx, &issue_id, &session_id).await;
                     run_after_run_hook(&shell_executor, &config.hooks, &ws_path);
                     emit_update(
                         &update_tx,
@@ -301,6 +325,7 @@ pub async fn run_agent_attempt(
                     let error_message = "turn cancelled".to_string();
                     warn!(%turn_id, "turn cancelled");
                     let _ = client.stop().await;
+                    emit_log_token_usage(&session_log_dir, &update_tx, &issue_id, &session_id).await;
                     run_after_run_hook(&shell_executor, &config.hooks, &ws_path);
                     emit_update(
                         &update_tx,
@@ -313,6 +338,7 @@ pub async fn run_agent_attempt(
                     let error_message = format!("turn error: {e}");
                     error!(error = %e, "turn error");
                     let _ = client.stop().await;
+                    emit_log_token_usage(&session_log_dir, &update_tx, &issue_id, &session_id).await;
                     run_after_run_hook(&shell_executor, &config.hooks, &ws_path);
                     emit_update(
                         &update_tx,
@@ -332,6 +358,11 @@ pub async fn run_agent_attempt(
         }
 
         let _ = client.stop().await;
+
+        // Scan Copilot log files for token usage metrics that aren't
+        // available over ACP in Copilot CLI 1.0.5.
+        emit_log_token_usage(&session_log_dir, &update_tx, &issue_id, &session_id).await;
+
         run_after_run_hook(&shell_executor, &config.hooks, &ws_path);
 
         info!(turns_max = max_turns, "agent run completed");
@@ -397,5 +428,42 @@ async fn emit_update(update_tx: &mpsc::Sender<AgentUpdate>, update: AgentUpdate)
             error = %e,
             "agent update receiver dropped"
         );
+    }
+}
+
+/// Best-effort scan of Copilot log directory for token usage metrics.
+/// Emits an `AgentUpdate` if any tokens are found. Safe to call when
+/// `session_log_dir` is `None` (no-op).
+async fn emit_log_token_usage(
+    session_log_dir: &Option<std::path::PathBuf>,
+    update_tx: &mpsc::Sender<AgentUpdate>,
+    issue_id: &str,
+    session_id: &str,
+) {
+    if let Some(ref log_dir) = session_log_dir {
+        let usage = log_parser::scan_log_dir(log_dir).await;
+        if usage.total_tokens > 0 || usage.prompt_tokens > 0 {
+            info!(
+                prompt = usage.prompt_tokens,
+                completion = usage.completion_tokens,
+                total = usage.total_tokens,
+                "token usage from log files"
+            );
+            emit_update(
+                update_tx,
+                AgentUpdate {
+                    issue_id: issue_id.to_string(),
+                    event: "token_usage".to_string(),
+                    message: Some("from log files".to_string()),
+                    input_tokens: Some(usage.prompt_tokens),
+                    output_tokens: Some(usage.completion_tokens),
+                    total_tokens: Some(usage.total_tokens),
+                    session_id: Some(session_id.to_string()),
+                },
+            )
+            .await;
+        } else {
+            info!(log_dir = %log_dir.display(), "no token usage found in log files");
+        }
     }
 }

--- a/rust/src/config/schema.rs
+++ b/rust/src/config/schema.rs
@@ -154,6 +154,9 @@ pub struct AgentConfig {
     pub read_timeout_ms: u64,
     pub stall_timeout_ms: u64,
     pub approval_policy: String,
+    /// Directory for Copilot CLI log files. When set, `--log-dir` is passed
+    /// to the agent process and log files are parsed for token usage metrics.
+    pub log_dir: Option<String>,
 }
 
 impl Default for AgentConfig {
@@ -168,6 +171,7 @@ impl Default for AgentConfig {
             read_timeout_ms: 30_000,
             stall_timeout_ms: 300_000,
             approval_policy: "auto-approve".to_string(),
+            log_dir: None,
         }
     }
 }

--- a/rust/src/tracker/github/adapter.rs
+++ b/rust/src/tracker/github/adapter.rs
@@ -189,7 +189,7 @@ impl Tracker for GitHubAdapter {
     async fn fetch_issue_states_by_ids(&self, ids: &[String]) -> Result<Vec<Issue>, TrackerError> {
         if self.project_enabled() {
             // For reconciliation, get project status for these specific issues
-            let all_states = self
+            let _all_states = self
                 .fetch_project_items(&[]) // fetch all statuses
                 .await
                 .unwrap_or_default();

--- a/rust/tests/log_parser_test.rs
+++ b/rust/tests/log_parser_test.rs
@@ -1,0 +1,186 @@
+use std::path::PathBuf;
+
+use rusty::agent::log_parser::{self, LogTokenUsage};
+
+// ── parse_token_line edge cases ──────────────────────────────────
+
+#[test]
+fn parse_all_three_fields_from_realistic_log_block() {
+    let lines = [
+        "2026-03-14T09:32:58Z INFO  assistant_usage prompt_tokens_count: 45760",
+        "2026-03-14T09:32:58Z INFO  assistant_usage completion_tokens_count: 658",
+        "2026-03-14T09:32:58Z INFO  assistant_usage total_tokens_count: 46418",
+    ];
+
+    let mut usage = LogTokenUsage::default();
+    for line in &lines {
+        if let Some((field, value)) = log_parser::parse_token_line(line) {
+            match field {
+                "prompt" => usage.prompt_tokens = usage.prompt_tokens.max(value),
+                "completion" => usage.completion_tokens = usage.completion_tokens.max(value),
+                "total" => usage.total_tokens = usage.total_tokens.max(value),
+                _ => {}
+            }
+        }
+    }
+
+    assert_eq!(usage.prompt_tokens, 45760);
+    assert_eq!(usage.completion_tokens, 658);
+    assert_eq!(usage.total_tokens, 46418);
+}
+
+#[test]
+fn parse_json_rpc_style_log_lines() {
+    let line = r#"{"jsonrpc":"2.0","method":"assistant_usage","params":{"prompt_tokens_count":12000,"completion_tokens_count":500,"total_tokens_count":12500}}"#;
+
+    // Should find the first matching field
+    let result = log_parser::parse_token_line(line);
+    assert!(result.is_some());
+    let (field, value) = result.unwrap();
+    assert_eq!(field, "prompt");
+    assert_eq!(value, 12000);
+}
+
+// ── scan_log_file integration ─────────────────────────────────────
+
+#[tokio::test]
+async fn scan_realistic_copilot_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_content = r#"
+2026-03-14T09:30:00Z INFO  Starting copilot session
+2026-03-14T09:30:01Z DEBUG Initialized ACP protocol
+2026-03-14T09:30:05Z INFO  assistant_usage prompt_tokens_count: 10000
+2026-03-14T09:30:05Z INFO  assistant_usage completion_tokens_count: 200
+2026-03-14T09:30:05Z INFO  assistant_usage total_tokens_count: 10200
+2026-03-14T09:31:00Z INFO  Turn 1 completed
+2026-03-14T09:31:05Z INFO  assistant_usage prompt_tokens_count: 25000
+2026-03-14T09:31:05Z INFO  assistant_usage completion_tokens_count: 450
+2026-03-14T09:31:05Z INFO  assistant_usage total_tokens_count: 25450
+2026-03-14T09:32:00Z INFO  Turn 2 completed
+2026-03-14T09:32:05Z INFO  assistant_usage prompt_tokens_count: 45760
+2026-03-14T09:32:05Z INFO  assistant_usage completion_tokens_count: 658
+2026-03-14T09:32:05Z INFO  assistant_usage total_tokens_count: 46418
+2026-03-14T09:32:30Z INFO  Session completed
+"#;
+
+    let log_path = dir.path().join("process-12345.log");
+    tokio::fs::write(&log_path, log_content).await.unwrap();
+
+    let usage = log_parser::scan_log_file(&log_path).await.unwrap();
+    assert_eq!(usage.prompt_tokens, 45760);
+    assert_eq!(usage.completion_tokens, 658);
+    assert_eq!(usage.total_tokens, 46418);
+}
+
+// ── scan_log_dir integration ──────────────────────────────────────
+
+#[tokio::test]
+async fn scan_dir_with_multiple_session_logs() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Session 1 log
+    tokio::fs::write(
+        dir.path().join("process-100.log"),
+        "prompt_tokens_count: 10000\ncompletion_tokens_count: 500\ntotal_tokens_count: 10500\n",
+    )
+    .await
+    .unwrap();
+
+    // Session 2 log with higher values
+    tokio::fs::write(
+        dir.path().join("process-200.log"),
+        "prompt_tokens_count: 50000\ncompletion_tokens_count: 1000\ntotal_tokens_count: 51000\n",
+    )
+    .await
+    .unwrap();
+
+    let usage = log_parser::scan_log_dir(dir.path()).await;
+    // scan_log_dir returns the max across files
+    assert_eq!(usage.prompt_tokens, 50000);
+    assert_eq!(usage.completion_tokens, 1000);
+    assert_eq!(usage.total_tokens, 51000);
+}
+
+#[tokio::test]
+async fn scan_dir_ignores_non_log_files() {
+    let dir = tempfile::tempdir().unwrap();
+
+    tokio::fs::write(
+        dir.path().join("config.yaml"),
+        "prompt_tokens_count: 99999\n",
+    )
+    .await
+    .unwrap();
+
+    tokio::fs::write(
+        dir.path().join("process-1.log"),
+        "prompt_tokens_count: 100\ncompletion_tokens_count: 10\ntotal_tokens_count: 110\n",
+    )
+    .await
+    .unwrap();
+
+    let usage = log_parser::scan_log_dir(dir.path()).await;
+    assert_eq!(usage.prompt_tokens, 100);
+    assert_eq!(usage.total_tokens, 110);
+}
+
+// ── config integration ────────────────────────────────────────────
+
+#[test]
+fn agent_config_log_dir_defaults_to_none() {
+    let config: rusty::config::schema::AgentConfig = Default::default();
+    assert!(config.log_dir.is_none());
+}
+
+#[test]
+fn agent_config_log_dir_deserializes_from_yaml() {
+    let yaml = r#"
+command: "copilot --acp"
+log_dir: "/tmp/copilot-logs"
+"#;
+    let config: rusty::config::schema::AgentConfig = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(config.log_dir.as_deref(), Some("/tmp/copilot-logs"));
+}
+
+#[test]
+fn agent_config_without_log_dir_deserializes() {
+    let yaml = r#"
+command: "copilot --acp"
+"#;
+    let config: rusty::config::schema::AgentConfig = serde_yaml::from_str(yaml).unwrap();
+    assert!(config.log_dir.is_none());
+}
+
+// ── command injection verification ────────────────────────────────
+
+#[test]
+fn log_dir_flag_injection_logic() {
+    // Simulate the flag injection logic from agent/mod.rs
+    let base_args = vec!["--acp", "--yolo", "--no-ask-user"];
+    let log_dir = Some(PathBuf::from("/tmp/logs/issue-42-20260314"));
+
+    let mut owned_args: Vec<String> = base_args.iter().map(|s| s.to_string()).collect();
+    if let Some(ref dir) = log_dir {
+        owned_args.push("--log-dir".to_string());
+        owned_args.push(dir.to_string_lossy().to_string());
+    }
+
+    assert_eq!(owned_args.len(), 5);
+    assert_eq!(owned_args[3], "--log-dir");
+    assert_eq!(owned_args[4], "/tmp/logs/issue-42-20260314");
+}
+
+#[test]
+fn no_log_dir_flag_when_none() {
+    let base_args = vec!["--acp", "--yolo", "--no-ask-user"];
+    let log_dir: Option<PathBuf> = None;
+
+    let mut owned_args: Vec<String> = base_args.iter().map(|s| s.to_string()).collect();
+    if let Some(ref dir) = log_dir {
+        owned_args.push("--log-dir".to_string());
+        owned_args.push(dir.to_string_lossy().to_string());
+    }
+
+    assert_eq!(owned_args.len(), 3);
+    assert!(!owned_args.contains(&"--log-dir".to_string()));
+}


### PR DESCRIPTION
## Summary

Copilot CLI 1.0.5 does not expose token usage data over the ACP protocol, causing token counts to show 0 in the API/dashboard. This PR implements Option 1 from issue #57: parse Copilot log files for token metrics.

## Changes

- **\ust/src/config/schema.rs\**: Add \log_dir: Option<String>\ to \AgentConfig\ — opt-in directory for Copilot CLI logs
- **\ust/src/agent/log_parser.rs\** (new): Module that parses \prompt_tokens_count\, \completion_tokens_count\, and \	otal_tokens_count\ from Copilot \process-*.log\ files
- **\ust/src/agent/mod.rs\**: Inject \--log-dir <path>\ into Copilot CLI command when configured; scan logs after session ends (success or failure); emit tokens via existing \AgentUpdate\ pipeline
- **\ust/tests/log_parser_test.rs\** (new): 10 integration tests for parsing, scanning, config deserialization, and command injection
- **\ust/src/tracker/github/adapter.rs\**: Fix pre-existing unused variable clippy warning

## How it works

1. User sets \gent.log_dir\ in config (e.g., \/tmp/copilot-logs\)
2. On agent launch, a per-session subdirectory is created and \--log-dir\ is appended to the command
3. After the agent session completes, all \.log\ files in the directory are scanned for token usage entries
4. The maximum values are emitted as \AgentUpdate\ with \vent: token_usage\, flowing into the existing delta-based \pply_token_update\ pipeline
5. When \log_dir\ is not set, behavior is completely unchanged

## Testing

- 14 unit tests in \log_parser.rs\ (inline)
- 10 integration tests in \	ests/log_parser_test.rs\
- All 20 pre-existing tests continue to pass
- \cargo clippy -- -D warnings\ clean

Closes #57