### PR TITLE
feat(rust): add ratatui terminal dashboard (#28)

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +216,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +307,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +371,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio 1.1.1",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +403,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -672,6 +766,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -930,6 +1026,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1065,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1091,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1003,6 +1127,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1091,6 +1224,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1114,7 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc623edee8a618b4543e8e8505584f4847a4e51b805db1af6d9af0a3395d0d57"
 dependencies = [
  "anymap2",
- "itertools",
+ "itertools 0.14.0",
  "kstring",
  "liquid-derive",
  "pest",
@@ -1141,7 +1280,7 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9befeedd61f5995bc128c571db65300aeb50d62e4f0542c88282dbcb5f72372a"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "liquid-core",
  "percent-encoding",
  "regex",
@@ -1169,6 +1308,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "matchers"
@@ -1216,6 +1364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1403,6 +1552,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1706,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +1840,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1671,7 +1860,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1723,10 +1912,12 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "crossterm",
  "dirs",
  "liquid",
  "mockall",
  "notify",
+ "ratatui",
  "reqwest",
  "serde",
  "serde_json",
@@ -1909,6 +2100,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.1.1",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +2169,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2025,7 +2259,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2388,6 +2622,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2862,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2885,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,6 +32,8 @@ anyhow = "1"
 async-trait = "0.1"
 dirs = "5"
 tower-http = { version = "0.5", features = ["cors"] }
+ratatui = "0.29"
+crossterm = "0.28"
 
 [dev-dependencies]
 mockall = "0.12"

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -1,6 +1,6 @@
 //! CLI entry point for Rusty (Rusty orchestration daemon).
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
 use tracing::{error, info};
 
@@ -16,7 +16,8 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
                   Quick start:\n  \
                     rusty setup              # Interactive first-time setup\n  \
                     rusty run --yolo         # Start the daemon\n  \
-                    rusty run --yolo --port 4000  # Start with web dashboard\n\n\
+                    rusty run --yolo --port 4000  # Start with web dashboard\n  \
+                    rusty dashboard --url http://127.0.0.1:4000  # Open terminal dashboard\n\n\
                   Docs: https://github.com/ridermw/rusty/blob/main/rust/README.md",
     after_help = "Environment variables:\n  \
                   GITHUB_TOKEN/GH_TOKEN  GitHub API token (or use gh auth login)\n  \
@@ -25,6 +26,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
                   rusty run --yolo\n  \
                   rusty run --yolo --port 4000 --logs-root ./logs\n  \
                   rusty run --yolo path/to/WORKFLOW.md\n  \
+                  rusty dashboard --url http://127.0.0.1:4000\n  \
                   rusty setup"
 )]
 pub struct Cli {
@@ -36,8 +38,21 @@ pub struct Cli {
 pub enum Commands {
     /// Start the orchestration daemon
     Run(RunArgs),
+    /// Watch orchestrator status in a terminal dashboard
+    Dashboard(DashboardArgs),
     /// Interactive first-time setup
     Setup,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct DashboardArgs {
+    /// Dashboard API URL (default: http://127.0.0.1:8080)
+    #[arg(long, default_value = "http://127.0.0.1:8080")]
+    pub url: String,
+
+    /// Refresh interval in seconds
+    #[arg(long, default_value = "2")]
+    pub refresh: u64,
 }
 
 #[derive(Parser, Debug)]
@@ -154,6 +169,7 @@ pub async fn run() -> anyhow::Result<()> {
     match cli.command {
         Commands::Setup => run_setup().await,
         Commands::Run(args) => run_daemon(args).await,
+        Commands::Dashboard(args) => crate::tui::run_dashboard(args).await,
     }
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,5 +7,6 @@ pub mod orchestrator;
 pub mod prompt;
 pub mod server;
 pub mod tracker;
+pub mod tui;
 pub mod workflow;
 pub mod workspace;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,8 +1,8 @@
-use rusty::cli;
+use rusty::cli::run;
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = cli::run().await {
+    if let Err(e) = run().await {
         eprintln!("Fatal: {e}");
         std::process::exit(1);
     }

--- a/rust/src/tui.rs
+++ b/rust/src/tui.rs
@@ -1,0 +1,874 @@
+use std::io;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
+
+use chrono::{DateTime, Local, Utc};
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    prelude::{Color, Frame, Line, Span, Style, Stylize},
+    symbols::border,
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap},
+    Terminal,
+};
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio::time::MissedTickBehavior;
+
+use crate::cli::DashboardArgs;
+use crate::dashboard::humanize_event;
+use crate::orchestrator::state::TokenTotals;
+use crate::orchestrator::{OrchestratorSnapshot, RetrySnapshot, RunningSnapshot};
+
+const BG: Color = Color::Rgb(26, 26, 46);
+const PANEL_BG: Color = Color::Rgb(22, 33, 62);
+const PANEL_ALT: Color = Color::Rgb(15, 52, 96);
+const ACCENT: Color = Color::Rgb(233, 69, 96);
+const TEXT: Color = Color::Rgb(238, 238, 238);
+const MUTED: Color = Color::Rgb(168, 175, 196);
+const INFO: Color = Color::Rgb(110, 168, 254);
+
+pub async fn run_dashboard(args: DashboardArgs) -> anyhow::Result<()> {
+    let refresh_interval = Duration::from_secs(args.refresh.max(1));
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?;
+
+    let mut app = DashboardApp::new(args.url);
+    let mut terminal = TerminalSession::new()?;
+    let (mut events, stop_events, event_task) = spawn_event_reader();
+    let mut tick = tokio::time::interval(refresh_interval);
+    tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+    refresh_snapshot(&client, &mut app, false).await;
+
+    loop {
+        terminal.draw(|frame| render(frame, &mut app))?;
+
+        tokio::select! {
+            _ = tick.tick() => {
+                refresh_snapshot(&client, &mut app, false).await;
+            }
+            maybe_event = events.recv() => {
+                match maybe_event {
+                    Some(event) => {
+                        if handle_event(event, &client, &mut app).await? {
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+            _ = tokio::signal::ctrl_c() => break,
+        }
+    }
+
+    stop_events.store(true, Ordering::Relaxed);
+    let _ = event_task.await;
+    Ok(())
+}
+
+struct DashboardApp {
+    base_url: String,
+    snapshot: OrchestratorSnapshot,
+    last_updated: Option<DateTime<Utc>>,
+    error: Option<String>,
+    running_scroll: usize,
+    retry_scroll: usize,
+    focus: TableFocus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TableFocus {
+    Running,
+    Retry,
+}
+
+impl DashboardApp {
+    fn new(base_url: String) -> Self {
+        Self {
+            base_url,
+            snapshot: empty_snapshot(),
+            last_updated: None,
+            error: None,
+            running_scroll: 0,
+            retry_scroll: 0,
+            focus: TableFocus::Running,
+        }
+    }
+
+    fn state_url(&self) -> String {
+        format!("{}/api/v1/state", self.base_url.trim_end_matches('/'))
+    }
+
+    fn refresh_url(&self) -> String {
+        format!("{}/api/v1/refresh", self.base_url.trim_end_matches('/'))
+    }
+
+    fn apply_snapshot(&mut self, state: DashboardStateResponse) {
+        self.snapshot = state.snapshot;
+        self.last_updated = state.generated_at.or_else(|| Some(Utc::now()));
+        self.error = None;
+    }
+
+    fn set_error(&mut self, error: impl Into<String>) {
+        self.error = Some(error.into());
+    }
+
+    fn scroll_up(&mut self) {
+        match self.focus {
+            TableFocus::Running => {
+                self.running_scroll = self.running_scroll.saturating_sub(1);
+            }
+            TableFocus::Retry => {
+                self.retry_scroll = self.retry_scroll.saturating_sub(1);
+            }
+        }
+    }
+
+    fn scroll_down(&mut self) {
+        match self.focus {
+            TableFocus::Running => {
+                self.running_scroll = self.running_scroll.saturating_add(1);
+            }
+            TableFocus::Retry => {
+                self.retry_scroll = self.retry_scroll.saturating_add(1);
+            }
+        }
+    }
+
+    fn toggle_focus(&mut self) {
+        self.focus = match self.focus {
+            TableFocus::Running => TableFocus::Retry,
+            TableFocus::Retry => TableFocus::Running,
+        };
+    }
+}
+
+struct TerminalSession {
+    terminal: Terminal<CrosstermBackend<io::Stdout>>,
+}
+
+impl TerminalSession {
+    fn new() -> io::Result<Self> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        execute!(stdout, EnterAlternateScreen)?;
+        let backend = CrosstermBackend::new(stdout);
+        let mut terminal = Terminal::new(backend)?;
+        terminal.hide_cursor()?;
+        terminal.clear()?;
+        Ok(Self { terminal })
+    }
+
+    fn draw<F>(&mut self, render: F) -> io::Result<()>
+    where
+        F: FnOnce(&mut Frame<'_>),
+    {
+        self.terminal.draw(render).map(|_| ())
+    }
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        let _ = disable_raw_mode();
+        let _ = execute!(self.terminal.backend_mut(), LeaveAlternateScreen);
+        let _ = self.terminal.show_cursor();
+    }
+}
+
+fn spawn_event_reader() -> (
+    mpsc::UnboundedReceiver<Event>,
+    Arc<AtomicBool>,
+    tokio::task::JoinHandle<()>,
+) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_signal = Arc::clone(&stop);
+
+    let handle = tokio::task::spawn_blocking(move || {
+        while !stop_signal.load(Ordering::Relaxed) {
+            match event::poll(Duration::from_millis(200)) {
+                Ok(true) => match event::read() {
+                    Ok(next) => {
+                        if tx.send(next).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                },
+                Ok(false) => continue,
+                Err(_) => break,
+            }
+        }
+    });
+
+    (rx, stop, handle)
+}
+
+async fn handle_event(
+    event: Event,
+    client: &reqwest::Client,
+    app: &mut DashboardApp,
+) -> anyhow::Result<bool> {
+    match event {
+        Event::Key(key) if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) => {
+            match key.code {
+                KeyCode::Char('q') => return Ok(true),
+                KeyCode::Char('r') => refresh_snapshot(client, app, true).await,
+                KeyCode::Tab => app.toggle_focus(),
+                KeyCode::Up => app.scroll_up(),
+                KeyCode::Down => app.scroll_down(),
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+
+    Ok(false)
+}
+
+async fn refresh_snapshot(client: &reqwest::Client, app: &mut DashboardApp, force: bool) {
+    let mut refresh_warning = None;
+
+    if force {
+        if let Err(error) = trigger_refresh(client, &app.refresh_url()).await {
+            refresh_warning = Some(format!("refresh request failed: {error}"));
+        }
+    }
+
+    match fetch_snapshot(client, &app.state_url()).await {
+        Ok(snapshot) => {
+            app.apply_snapshot(snapshot);
+            if let Some(warning) = refresh_warning {
+                app.set_error(warning);
+            }
+        }
+        Err(error) => match refresh_warning {
+            Some(warning) => app.set_error(format!("{warning}; state refresh failed: {error}")),
+            None => app.set_error(format!("state refresh failed: {error}")),
+        },
+    }
+}
+
+async fn fetch_snapshot(
+    client: &reqwest::Client,
+    state_url: &str,
+) -> anyhow::Result<DashboardStateResponse> {
+    let response = client.get(state_url).send().await?.error_for_status()?;
+    let payload: DashboardApiResponse = response.json().await?;
+    Ok(payload.into_state())
+}
+
+async fn trigger_refresh(client: &reqwest::Client, refresh_url: &str) -> anyhow::Result<()> {
+    client.post(refresh_url).send().await?.error_for_status()?;
+    Ok(())
+}
+
+fn render(frame: &mut Frame<'_>, app: &mut DashboardApp) {
+    let area = frame.area();
+    frame.render_widget(
+        Block::default().style(Style::default().bg(BG).fg(TEXT)),
+        area,
+    );
+
+    if area.width < 80 || area.height < 20 {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_set(border::ROUNDED)
+            .border_style(Style::default().fg(ACCENT))
+            .style(Style::default().bg(BG).fg(TEXT));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        frame.render_widget(
+            Paragraph::new("Resize terminal to at least 80x20 to view the dashboard.")
+                .style(Style::default().fg(TEXT).bg(BG))
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: true }),
+            inner,
+        );
+        return;
+    }
+
+    let outer = Block::default()
+        .borders(Borders::ALL)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(ACCENT))
+        .style(Style::default().bg(BG).fg(TEXT));
+    let inner = outer.inner(area);
+    frame.render_widget(outer, area);
+
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(5),
+            Constraint::Min(6),
+            Constraint::Min(5),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+    render_header(frame, sections[0], app.last_updated);
+    render_metrics(frame, sections[1], &app.snapshot);
+    render_running_table(frame, sections[2], app);
+    render_retry_table(frame, sections[3], app);
+    render_footer(frame, sections[4], app.error.as_deref());
+}
+
+fn render_header(frame: &mut Frame<'_>, area: Rect, last_updated: Option<DateTime<Utc>>) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(20), Constraint::Length(28)])
+        .split(area);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![Span::styled(
+            "🦀 Rusty Dashboard",
+            Style::default().fg(ACCENT).bold(),
+        )]))
+        .style(Style::default().bg(BG).fg(TEXT)),
+        chunks[0],
+    );
+
+    frame.render_widget(
+        Paragraph::new(format!(
+            "Last updated: {}",
+            format_last_updated(last_updated)
+        ))
+        .style(Style::default().bg(BG).fg(MUTED))
+        .alignment(Alignment::Right),
+        chunks[1],
+    );
+}
+
+fn render_metrics(frame: &mut Frame<'_>, area: Rect, snapshot: &OrchestratorSnapshot) {
+    let cards = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+        ])
+        .split(area);
+
+    render_metric_card(
+        frame,
+        cards[0],
+        "Running",
+        format_with_commas(snapshot.running_count as u64),
+        Color::Green,
+    );
+    render_metric_card(
+        frame,
+        cards[1],
+        "Retrying",
+        format_with_commas(snapshot.retrying_count as u64),
+        Color::Yellow,
+    );
+    render_metric_card(
+        frame,
+        cards[2],
+        "Tokens",
+        format_with_commas(snapshot.agent_totals.total_tokens),
+        ACCENT,
+    );
+    render_metric_card(
+        frame,
+        cards[3],
+        "Runtime",
+        format_runtime(snapshot.agent_totals.seconds_running),
+        INFO,
+    );
+}
+
+fn render_metric_card(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    title: &str,
+    value: String,
+    value_color: Color,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(PANEL_ALT))
+        .style(Style::default().bg(PANEL_BG).fg(TEXT));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(Span::styled(title, Style::default().fg(MUTED))),
+            Line::from(Span::styled(value, Style::default().fg(value_color).bold())),
+        ])
+        .style(Style::default().bg(PANEL_BG).fg(TEXT))
+        .alignment(Alignment::Center),
+        inner,
+    );
+}
+
+fn render_running_table(frame: &mut Frame<'_>, area: Rect, app: &mut DashboardApp) {
+    let block = section_block(
+        " Running Sessions ",
+        matches!(app.focus, TableFocus::Running),
+    );
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if app.snapshot.running.is_empty() {
+        frame.render_widget(
+            Paragraph::new("No running sessions.")
+                .style(Style::default().bg(PANEL_BG).fg(MUTED))
+                .alignment(Alignment::Left),
+            inner,
+        );
+        return;
+    }
+
+    let visible_rows = inner.height.saturating_sub(1) as usize;
+    let max_scroll = app.snapshot.running.len().saturating_sub(visible_rows);
+    app.running_scroll = app.running_scroll.min(max_scroll);
+
+    let rows = app
+        .snapshot
+        .running
+        .iter()
+        .skip(app.running_scroll)
+        .take(visible_rows)
+        .enumerate()
+        .map(|(index, session)| running_row(index, session));
+
+    let header = Row::new(vec!["Issue", "State", "Turns", "Update", "Tokens"])
+        .style(Style::default().fg(ACCENT).bg(PANEL_BG).bold());
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(12),
+            Constraint::Length(12),
+            Constraint::Length(7),
+            Constraint::Min(12),
+            Constraint::Length(12),
+        ],
+    )
+    .header(header)
+    .column_spacing(1)
+    .style(Style::default().bg(PANEL_BG).fg(TEXT));
+
+    frame.render_widget(table, inner);
+}
+
+fn render_retry_table(frame: &mut Frame<'_>, area: Rect, app: &mut DashboardApp) {
+    let block = section_block(" Retry Queue ", matches!(app.focus, TableFocus::Retry));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if app.snapshot.retrying.is_empty() {
+        frame.render_widget(
+            Paragraph::new("No retrying sessions.")
+                .style(Style::default().bg(PANEL_BG).fg(MUTED))
+                .alignment(Alignment::Left),
+            inner,
+        );
+        return;
+    }
+
+    let visible_rows = inner.height.saturating_sub(1) as usize;
+    let max_scroll = app.snapshot.retrying.len().saturating_sub(visible_rows);
+    app.retry_scroll = app.retry_scroll.min(max_scroll);
+
+    let rows = app
+        .snapshot
+        .retrying
+        .iter()
+        .skip(app.retry_scroll)
+        .take(visible_rows)
+        .enumerate()
+        .map(|(index, session)| retry_row(index, session));
+
+    let header = Row::new(vec!["Issue", "Attempt", "Due at", "Error"])
+        .style(Style::default().fg(ACCENT).bg(PANEL_BG).bold());
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(12),
+            Constraint::Length(9),
+            Constraint::Length(10),
+            Constraint::Min(16),
+        ],
+    )
+    .header(header)
+    .column_spacing(1)
+    .style(Style::default().bg(PANEL_BG).fg(TEXT));
+
+    frame.render_widget(table, inner);
+}
+
+fn render_footer(frame: &mut Frame<'_>, area: Rect, error: Option<&str>) {
+    let mut spans = vec![
+        Span::styled("q", Style::default().fg(ACCENT).bold()),
+        Span::styled(": quit  ", Style::default().fg(MUTED)),
+        Span::styled("r", Style::default().fg(ACCENT).bold()),
+        Span::styled(": refresh  ", Style::default().fg(MUTED)),
+        Span::styled("tab", Style::default().fg(ACCENT).bold()),
+        Span::styled(": switch  ", Style::default().fg(MUTED)),
+        Span::styled("↑↓", Style::default().fg(ACCENT).bold()),
+        Span::styled(": scroll", Style::default().fg(MUTED)),
+    ];
+
+    if let Some(error) = error {
+        spans.push(Span::styled("  •  ", Style::default().fg(MUTED)));
+        spans.push(Span::styled(
+            truncate_with_ellipsis(error, 60),
+            Style::default().fg(Color::Red),
+        ));
+    }
+
+    frame.render_widget(
+        Paragraph::new(Line::from(spans))
+            .style(Style::default().bg(BG).fg(MUTED))
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn section_block<'a>(title: &'a str, focused: bool) -> Block<'a> {
+    let border_color = if focused { ACCENT } else { PANEL_ALT };
+    let title_style = if focused {
+        Style::default().fg(ACCENT).bold()
+    } else {
+        Style::default().fg(TEXT).bold()
+    };
+
+    Block::default()
+        .title(title)
+        .title_style(title_style)
+        .borders(Borders::ALL)
+        .border_set(border::ROUNDED)
+        .border_style(Style::default().fg(border_color))
+        .style(Style::default().bg(PANEL_BG).fg(TEXT))
+}
+
+fn running_row(index: usize, running: &RunningSnapshot) -> Row<'static> {
+    let row_bg = if index % 2 == 0 { PANEL_BG } else { BG };
+    let update = humanize_update(
+        running.last_event.as_deref(),
+        running.last_message.as_deref(),
+    );
+
+    Row::new(vec![
+        Cell::from(truncate_with_ellipsis(&running.identifier, 12)),
+        Cell::from(running.state.clone()).style(Style::default().fg(state_color(&running.state))),
+        Cell::from(running.turn_count.to_string()),
+        Cell::from(truncate_with_ellipsis(&update, 18)),
+        Cell::from(format_with_commas(running.total_tokens)),
+    ])
+    .style(Style::default().bg(row_bg).fg(TEXT))
+}
+
+fn retry_row(index: usize, retry: &RetrySnapshot) -> Row<'static> {
+    let row_bg = if index % 2 == 0 { PANEL_BG } else { BG };
+
+    Row::new(vec![
+        Cell::from(truncate_with_ellipsis(&retry.identifier, 12)),
+        Cell::from(retry.attempt.to_string()),
+        Cell::from(format_due_at(&retry.due_at)),
+        Cell::from(truncate_with_ellipsis(
+            retry.error.as_deref().unwrap_or("-"),
+            28,
+        )),
+    ])
+    .style(Style::default().bg(row_bg).fg(TEXT))
+}
+
+fn humanize_update(last_event: Option<&str>, last_message: Option<&str>) -> String {
+    if let Some(event) = last_event.filter(|event| !event.trim().is_empty()) {
+        let display = humanize_event(event);
+        if display == event {
+            return last_message
+                .filter(|message| !message.trim().is_empty())
+                .unwrap_or(display)
+                .to_string();
+        }
+        return display.to_string();
+    }
+
+    last_message
+        .filter(|message| !message.trim().is_empty())
+        .unwrap_or("-")
+        .to_string()
+}
+
+fn format_due_at(value: &str) -> String {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| {
+            timestamp
+                .with_timezone(&Local)
+                .format("%H:%M:%S")
+                .to_string()
+        })
+        .unwrap_or_else(|_| truncate_with_ellipsis(value, 10))
+}
+
+fn format_last_updated(value: Option<DateTime<Utc>>) -> String {
+    value
+        .map(|timestamp| {
+            timestamp
+                .with_timezone(&Local)
+                .format("%H:%M:%S")
+                .to_string()
+        })
+        .unwrap_or_else(|| "--:--:--".to_string())
+}
+
+fn format_with_commas(value: u64) -> String {
+    let digits = value.to_string();
+    let mut reversed = String::with_capacity(digits.len() + digits.len() / 3);
+
+    for (index, ch) in digits.chars().rev().enumerate() {
+        if index != 0 && index % 3 == 0 {
+            reversed.push(',');
+        }
+        reversed.push(ch);
+    }
+
+    reversed.chars().rev().collect()
+}
+
+fn format_runtime(seconds_running: f64) -> String {
+    let total_seconds = seconds_running.max(0.0).floor() as u64;
+
+    if total_seconds < 60 {
+        format!("{total_seconds}s")
+    } else if total_seconds < 3_600 {
+        format!("{}m {}s", total_seconds / 60, total_seconds % 60)
+    } else {
+        format!(
+            "{}h {}m",
+            total_seconds / 3_600,
+            (total_seconds % 3_600) / 60
+        )
+    }
+}
+
+fn state_color(state: &str) -> Color {
+    if state.eq_ignore_ascii_case("inprogress") {
+        Color::Green
+    } else if state.eq_ignore_ascii_case("todo") {
+        Color::Yellow
+    } else if state.eq_ignore_ascii_case("failed") {
+        Color::Red
+    } else {
+        TEXT
+    }
+}
+
+fn truncate_with_ellipsis(value: &str, max_chars: usize) -> String {
+    let count = value.chars().count();
+    if count <= max_chars {
+        return value.to_string();
+    }
+
+    if max_chars <= 1 {
+        return "…".to_string();
+    }
+
+    let mut truncated: String = value.chars().take(max_chars - 1).collect();
+    truncated.push('…');
+    truncated
+}
+
+fn empty_snapshot() -> OrchestratorSnapshot {
+    OrchestratorSnapshot {
+        running_count: 0,
+        retrying_count: 0,
+        running: Vec::new(),
+        retrying: Vec::new(),
+        agent_totals: TokenTotals::default(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DashboardApiResponse {
+    generated_at: String,
+    counts: DashboardCounts,
+    running: Vec<ApiRunningSnapshot>,
+    retrying: Vec<ApiRetrySnapshot>,
+    codex_totals: ApiTokenTotals,
+}
+
+impl DashboardApiResponse {
+    fn into_state(self) -> DashboardStateResponse {
+        DashboardStateResponse {
+            generated_at: DateTime::parse_from_rfc3339(&self.generated_at)
+                .ok()
+                .map(|timestamp| timestamp.with_timezone(&Utc)),
+            snapshot: OrchestratorSnapshot {
+                running_count: self.counts.running,
+                retrying_count: self.counts.retrying,
+                running: self.running.into_iter().map(Into::into).collect(),
+                retrying: self.retrying.into_iter().map(Into::into).collect(),
+                agent_totals: self.codex_totals.into(),
+            },
+        }
+    }
+}
+
+struct DashboardStateResponse {
+    generated_at: Option<DateTime<Utc>>,
+    snapshot: OrchestratorSnapshot,
+}
+
+#[derive(Debug, Deserialize)]
+struct DashboardCounts {
+    running: usize,
+    retrying: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiRunningSnapshot {
+    issue_id: String,
+    identifier: String,
+    state: String,
+    session_id: Option<String>,
+    turn_count: u32,
+    last_event: Option<String>,
+    last_message: Option<String>,
+    started_at: String,
+    input_tokens: u64,
+    output_tokens: u64,
+    total_tokens: u64,
+}
+
+impl From<ApiRunningSnapshot> for RunningSnapshot {
+    fn from(value: ApiRunningSnapshot) -> Self {
+        Self {
+            issue_id: value.issue_id,
+            identifier: value.identifier,
+            state: value.state,
+            session_id: value.session_id,
+            turn_count: value.turn_count,
+            last_event: value.last_event,
+            last_message: value.last_message,
+            started_at: value.started_at,
+            input_tokens: value.input_tokens,
+            output_tokens: value.output_tokens,
+            total_tokens: value.total_tokens,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiRetrySnapshot {
+    issue_id: String,
+    identifier: String,
+    attempt: u32,
+    due_at: String,
+    error: Option<String>,
+}
+
+impl From<ApiRetrySnapshot> for RetrySnapshot {
+    fn from(value: ApiRetrySnapshot) -> Self {
+        Self {
+            issue_id: value.issue_id,
+            identifier: value.identifier,
+            attempt: value.attempt,
+            due_at: value.due_at,
+            error: value.error,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiTokenTotals {
+    input_tokens: u64,
+    output_tokens: u64,
+    total_tokens: u64,
+    seconds_running: f64,
+}
+
+impl From<ApiTokenTotals> for TokenTotals {
+    fn from(value: ApiTokenTotals) -> Self {
+        Self {
+            input_tokens: value.input_tokens,
+            output_tokens: value.output_tokens,
+            total_tokens: value.total_tokens,
+            seconds_running: value.seconds_running,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_runtime, format_with_commas, state_color, DashboardApiResponse};
+    use ratatui::style::Color;
+
+    #[test]
+    fn format_with_commas_inserts_grouping() {
+        assert_eq!(format_with_commas(0), "0");
+        assert_eq!(format_with_commas(1_200), "1,200");
+        assert_eq!(format_with_commas(12_345_678), "12,345,678");
+    }
+
+    #[test]
+    fn format_runtime_uses_expected_units() {
+        assert_eq!(format_runtime(42.0), "42s");
+        assert_eq!(format_runtime(923.5), "15m 23s");
+        assert_eq!(format_runtime(7_380.0), "2h 3m");
+    }
+
+    #[test]
+    fn state_color_maps_known_states() {
+        assert_eq!(state_color("InProgress"), Color::Green);
+        assert_eq!(state_color("Todo"), Color::Yellow);
+        assert_eq!(state_color("Failed"), Color::Red);
+    }
+
+    #[test]
+    fn dashboard_api_response_deserializes_into_snapshot() {
+        let payload = r#"{
+            "generated_at": "2026-03-14T10:01:46Z",
+            "counts": { "running": 2, "retrying": 0 },
+            "running": [
+                {
+                    "issue_id": "28",
+                    "identifier": "rusty-28",
+                    "state": "InProgress",
+                    "session_id": "abc-123",
+                    "turn_count": 3,
+                    "last_event": "notification",
+                    "last_message": "session update",
+                    "started_at": "2026-03-14T10:01:24Z",
+                    "input_tokens": 500,
+                    "output_tokens": 200,
+                    "total_tokens": 700
+                }
+            ],
+            "retrying": [],
+            "codex_totals": {
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "total_tokens": 1500,
+                "seconds_running": 923.5
+            },
+            "rate_limits": null
+        }"#;
+
+        let response: DashboardApiResponse = serde_json::from_str(payload).expect("valid payload");
+        let state = response.into_state();
+
+        assert_eq!(state.snapshot.running_count, 2);
+        assert_eq!(state.snapshot.retrying_count, 0);
+        assert_eq!(state.snapshot.running[0].identifier, "rusty-28");
+        assert_eq!(state.snapshot.agent_totals.total_tokens, 1_500);
+        assert!(state.generated_at.is_some());
+    }
+}


### PR DESCRIPTION
Closes #28. Full terminal dashboard with ratatui. 4 metric cards, running sessions table, retry queue, keyboard nav, auto-refresh. 56 tests pass.