### PR TITLE
test(rust): pure function coverage — prompt, dashboard, workflow, config helpers

### DIFF
--- a/rust/tests/config_test.rs
+++ b/rust/tests/config_test.rs
@@ -400,6 +400,48 @@ fn effective_terminal_states_merge_labels_without_duplicates() {
 }
 
 #[test]
+fn full_repo_returns_none_with_owner_only() {
+    use rusty::config::schema::TrackerConfig;
+    let mut config = TrackerConfig::default();
+    config.owner = Some("ridermw".to_string());
+    assert_eq!(config.full_repo(), None);
+}
+
+#[test]
+fn effective_active_states_returns_defaults_when_labels_empty() {
+    let config = rusty::config::schema::TrackerConfig::default();
+    assert_eq!(config.effective_active_states(), vec!["open".to_string()]);
+}
+
+#[test]
+fn effective_terminal_states_returns_defaults_when_labels_empty() {
+    let config = rusty::config::schema::TrackerConfig::default();
+    assert_eq!(
+        config.effective_terminal_states(),
+        vec!["closed".to_string()]
+    );
+}
+
+#[test]
+fn tracker_config_default_field_values() {
+    use rusty::config::schema::TrackerConfig;
+    let config = TrackerConfig::default();
+    assert_eq!(config.kind, None);
+    assert_eq!(config.endpoint, None);
+    assert_eq!(config.api_key, None);
+    assert_eq!(config.owner, None);
+    assert_eq!(config.repo, None);
+    assert_eq!(config.project_number, None);
+    assert_eq!(config.active_states, vec!["open".to_string()]);
+    assert_eq!(config.terminal_states, vec!["closed".to_string()]);
+    assert!(config.labels.is_empty());
+    assert!(config.active_issue_labels.is_empty());
+    assert!(config.terminal_issue_labels.is_empty());
+    assert!(config.state_labels.is_empty());
+    assert_eq!(config.assignee, None);
+}
+
+#[test]
 fn agent_launch_command_returns_agent_command_directly() {
     let config = RustyConfig::default();
     assert_eq!(

--- a/rust/tests/dashboard_test.rs
+++ b/rust/tests/dashboard_test.rs
@@ -92,6 +92,147 @@ fn humanize_event_unknown_value_returns_original_value() {
 }
 
 #[test]
+fn humanize_event_session_started_returns_started() {
+    assert_eq!(humanize_event("session_started"), "Started");
+}
+
+#[test]
+fn humanize_event_turn_failed_returns_turn_failed() {
+    assert_eq!(humanize_event("turn_failed"), "Turn FAILED");
+}
+
+#[test]
+fn humanize_event_turn_cancelled_returns_cancelled() {
+    assert_eq!(humanize_event("turn_cancelled"), "Cancelled");
+}
+
+#[test]
+fn humanize_event_notification_returns_working() {
+    assert_eq!(humanize_event("notification"), "Working");
+}
+
+#[test]
+fn humanize_event_approval_auto_approved_returns_auto_approved() {
+    assert_eq!(humanize_event("approval_auto_approved"), "Auto-approved");
+}
+
+#[test]
+fn render_dashboard_with_multiple_running_sessions() {
+    let snapshot = OrchestratorSnapshot {
+        running_count: 3,
+        retrying_count: 0,
+        running: vec![
+            RunningSnapshot {
+                issue_id: "1".into(),
+                identifier: "ISSUE-1".into(),
+                state: "running".into(),
+                session_id: Some("s1".into()),
+                turn_count: 2,
+                last_event: Some("turn_completed".into()),
+                last_message: Some("Making progress".into()),
+                started_at: "2024-01-01T00:00:00Z".into(),
+                input_tokens: 10,
+                output_tokens: 5,
+                total_tokens: 15,
+            },
+            RunningSnapshot {
+                issue_id: "2".into(),
+                identifier: "ISSUE-2".into(),
+                state: "running".into(),
+                session_id: Some("s2".into()),
+                turn_count: 5,
+                last_event: Some("notification".into()),
+                last_message: Some("Thinking".into()),
+                started_at: "2024-01-01T00:01:00Z".into(),
+                input_tokens: 20,
+                output_tokens: 10,
+                total_tokens: 30,
+            },
+            RunningSnapshot {
+                issue_id: "3".into(),
+                identifier: "ISSUE-3".into(),
+                state: "running".into(),
+                session_id: Some("s3".into()),
+                turn_count: 1,
+                last_event: Some("session_started".into()),
+                last_message: Some("Starting".into()),
+                started_at: "2024-01-01T00:02:00Z".into(),
+                input_tokens: 5,
+                output_tokens: 2,
+                total_tokens: 7,
+            },
+        ],
+        retrying: vec![],
+        agent_totals: TokenTotals {
+            input_tokens: 35,
+            output_tokens: 17,
+            total_tokens: 52,
+            seconds_running: 30.0,
+        },
+    };
+
+    let output = render_dashboard(&snapshot);
+
+    assert!(output.contains("Running: 3"));
+    assert!(output.contains("ISSUE-1"));
+    assert!(output.contains("ISSUE-2"));
+    assert!(output.contains("ISSUE-3"));
+}
+
+#[test]
+fn render_dashboard_retry_entry_with_no_error() {
+    let snapshot = OrchestratorSnapshot {
+        running_count: 0,
+        retrying_count: 1,
+        running: vec![],
+        retrying: vec![RetrySnapshot {
+            issue_id: "1".into(),
+            identifier: "ISSUE-1".into(),
+            attempt: 3,
+            due_at: "2024-06-01T12:00:00Z".into(),
+            error: None,
+        }],
+        agent_totals: TokenTotals::default(),
+    };
+
+    let output = render_dashboard(&snapshot);
+
+    assert!(output.contains("── Retry Queue ──"));
+    assert!(output.contains("ISSUE-1"));
+    assert!(output.contains("attempt:3"));
+    assert!(output.contains("-"));
+}
+
+#[test]
+fn render_dashboard_running_entry_with_no_optional_fields() {
+    let snapshot = OrchestratorSnapshot {
+        running_count: 1,
+        retrying_count: 0,
+        running: vec![RunningSnapshot {
+            issue_id: "1".into(),
+            identifier: "ISSUE-4".into(),
+            state: "starting".into(),
+            session_id: None,
+            turn_count: 0,
+            last_event: None,
+            last_message: None,
+            started_at: "2024-01-01T00:00:00Z".into(),
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+        }],
+        retrying: vec![],
+        agent_totals: TokenTotals::default(),
+    };
+
+    let output = render_dashboard(&snapshot);
+
+    assert!(output.contains("ISSUE-4"));
+    assert!(output.contains("[starting]"));
+    assert!(output.contains("turns:0"));
+}
+
+#[test]
 fn render_dashboard_truncates_long_messages_at_sixty_chars() {
     let long_message = format!("{}TRUNCATED", "a".repeat(60));
     let snapshot = OrchestratorSnapshot {

--- a/rust/tests/prompt_test.rs
+++ b/rust/tests/prompt_test.rs
@@ -100,3 +100,37 @@ fn missing_attempt_variable_is_falsey_in_conditionals() {
 
     assert_eq!(rendered, "");
 }
+
+#[test]
+fn renders_none_description_as_empty_string() {
+    let issue = test_issue("1", "ISSUE-1", "No desc issue", "open", None);
+
+    let rendered =
+        render_prompt("desc=[{{ issue.description }}]", &issue, None).unwrap();
+
+    assert_eq!(rendered, "desc=[]");
+}
+
+#[test]
+fn renders_special_characters_in_fields() {
+    let mut issue = test_issue("1", "ISSUE-1", "Fix <html> & \"quotes\"", "open", None);
+    issue.description = Some("Héllo wörld 🚀 foo&bar".to_string());
+
+    let rendered = render_prompt(
+        "{{ issue.title }} — {{ issue.description }}",
+        &issue,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(rendered, "Fix <html> & \"quotes\" — Héllo wörld 🚀 foo&bar");
+}
+
+#[test]
+fn returns_parse_error_for_invalid_liquid_syntax() {
+    let issue = sample_issue();
+
+    let error = render_prompt("{% if %}", &issue, None).unwrap_err();
+
+    assert!(matches!(error, ConfigError::TemplateParseError(_)));
+}

--- a/rust/tests/workflow_test.rs
+++ b/rust/tests/workflow_test.rs
@@ -100,6 +100,22 @@ fn parse_workflow_preserves_unknown_top_level_keys() {
     assert_eq!(definition.config, expected_config);
 }
 
+#[test]
+fn parse_workflow_rejects_unclosed_front_matter() {
+    let error = parse_workflow("---\ntracker:\n  kind: github\nprompt text\n")
+        .expect_err("unclosed front matter should fail");
+
+    assert!(matches!(error, ConfigError::WorkflowParseError(msg) if msg.contains("no closing ---")));
+}
+
+#[test]
+fn parse_workflow_handles_empty_front_matter_section() {
+    let definition = parse_workflow("---\n---\nHello prompt\n").expect("empty front matter should parse");
+
+    assert_eq!(definition.config, empty_mapping());
+    assert_eq!(definition.prompt_template, "Hello prompt");
+}
+
 #[tokio::test]
 async fn workflow_store_reloads_valid_changes() {
     let temp_dir = tempdir().expect("temp dir should be created");


### PR DESCRIPTION
Add 17 new tests across 4 pure/deterministic modules (zero external deps):

**prompt_test.rs** (8 → 11 tests, +3):
- \enders_none_description_as_empty_string\ — None description renders as empty
- \enders_special_characters_in_fields\ — HTML entities, unicode, emoji
- \eturns_parse_error_for_invalid_liquid_syntax\ — bad Liquid template

**dashboard_test.rs** (6 → 14 tests, +8):
- All \humanize_event\ variants: session_started, turn_failed, turn_cancelled, notification, approval_auto_approved
- \ender_dashboard_with_multiple_running_sessions\ — 3 concurrent sessions
- \ender_dashboard_retry_entry_with_no_error\ — retry with \None\ error
- \ender_dashboard_running_entry_with_no_optional_fields\ — no session_id/event/message

**workflow_test.rs** (8 → 10 tests, +2):
- \parse_workflow_rejects_unclosed_front_matter\ — opening \---\ but no closing
- \parse_workflow_handles_empty_front_matter_section\ — empty YAML between delimiters

**config_test.rs** (24 → 28 tests, +4):
- \ull_repo_returns_none_with_owner_only\ — owner set but no repo
- \ffective_active_states_returns_defaults_when_labels_empty\
- \ffective_terminal_states_returns_defaults_when_labels_empty\
- \	racker_config_default_field_values\ — all TrackerConfig default fields

All 63 tests pass. All pure functions, no mocking needed.

Closes #78