### PR TITLE
test(rust): extract traits for testability — HttpClient, ProcessRunner, FileSystem

### DIFF
--- a/rust/src/config/mod.rs
+++ b/rust/src/config/mod.rs
@@ -4,6 +4,8 @@ use self::schema::RustyConfig;
 use std::{collections::HashMap, env, path::PathBuf};
 use thiserror::Error;
 
+use crate::ports::{ProcessRunner, TokioProcessRunner};
+
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("missing workflow file: {0}")]
@@ -44,6 +46,14 @@ pub fn resolve_env_value(value: &str) -> Result<String, ConfigError> {
 ///
 /// Returns the token string or an error if no source provides one.
 pub async fn resolve_github_token(config_value: Option<&str>) -> Result<String, ConfigError> {
+    resolve_github_token_with(config_value, &TokioProcessRunner).await
+}
+
+/// Same as [`resolve_github_token`] but accepts an injectable [`ProcessRunner`].
+pub async fn resolve_github_token_with(
+    config_value: Option<&str>,
+    process: &dyn ProcessRunner,
+) -> Result<String, ConfigError> {
     match config_value {
         Some(val) if !val.is_empty() && !val.starts_with('$') => return Ok(val.to_string()),
         Some(val) if !val.is_empty() && val != "$GITHUB_TOKEN" && val != "$GH_TOKEN" => {
@@ -64,12 +74,8 @@ pub async fn resolve_github_token(config_value: Option<&str>) -> Result<String, 
         }
     }
 
-    match tokio::process::Command::new("gh")
-        .args(["auth", "token"])
-        .output()
-        .await
-    {
-        Ok(output) if output.status.success() => {
+    match process.run("gh", &["auth", "token"]).await {
+        Ok(output) if output.status_success => {
             let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if !token.is_empty() {
                 return Ok(token);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod dashboard;
 pub mod logging;
 pub mod orchestrator;
+pub mod ports;
 pub mod prompt;
 pub mod server;
 pub mod tracker;

--- a/rust/src/ports.rs
+++ b/rust/src/ports.rs
@@ -1,0 +1,264 @@
+//! Trait-based abstractions ("ports") for external dependencies.
+//!
+//! Each trait has a production implementation that delegates to the real
+//! subsystem (reqwest, tokio::process, std::fs) and can be swapped with a
+//! mock in tests.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use async_trait::async_trait;
+
+// ---------------------------------------------------------------------------
+// HttpClient
+// ---------------------------------------------------------------------------
+
+/// A minimal HTTP response surface used by our domain code.
+#[derive(Debug, Clone)]
+pub struct HttpResponse {
+    pub status: u16,
+    pub headers: HashMap<String, String>,
+    body: HttpBody,
+}
+
+#[derive(Debug, Clone)]
+enum HttpBody {
+    Bytes(Vec<u8>),
+}
+
+impl HttpResponse {
+    pub fn new(status: u16, headers: HashMap<String, String>, body: Vec<u8>) -> Self {
+        Self {
+            status,
+            headers,
+            body: HttpBody::Bytes(body),
+        }
+    }
+
+    /// Deserialize the body as JSON.
+    pub fn json<T: serde::de::DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
+        let HttpBody::Bytes(ref bytes) = self.body;
+        serde_json::from_slice(bytes)
+    }
+
+    /// Return the body as a UTF-8 string (lossy).
+    pub fn text(&self) -> String {
+        let HttpBody::Bytes(ref bytes) = self.body;
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+
+    pub fn header(&self, key: &str) -> Option<&str> {
+        self.headers.get(&key.to_lowercase()).map(|v| v.as_str())
+    }
+}
+
+/// Abstraction over HTTP GET/POST used by tracker and TUI code.
+#[async_trait]
+pub trait HttpClient: Send + Sync {
+    async fn get(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, HttpClientError>;
+
+    async fn post(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+        body: Option<&[u8]>,
+    ) -> Result<HttpResponse, HttpClientError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum HttpClientError {
+    #[error("HTTP request failed: {0}")]
+    Request(String),
+}
+
+/// Production implementation backed by `reqwest::Client`.
+#[derive(Debug, Clone)]
+pub struct ReqwestHttpClient {
+    inner: reqwest::Client,
+}
+
+impl ReqwestHttpClient {
+    pub fn new() -> Self {
+        Self {
+            inner: reqwest::Client::new(),
+        }
+    }
+
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { inner: client }
+    }
+}
+
+impl Default for ReqwestHttpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn collect_headers(response: &reqwest::Response) -> HashMap<String, String> {
+    response
+        .headers()
+        .iter()
+        .filter_map(|(k, v)| v.to_str().ok().map(|v| (k.as_str().to_lowercase(), v.to_string())))
+        .collect()
+}
+
+#[async_trait]
+impl HttpClient for ReqwestHttpClient {
+    async fn get(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<HttpResponse, HttpClientError> {
+        let mut builder = self.inner.get(url);
+        for &(key, value) in headers {
+            builder = builder.header(key, value);
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|e| HttpClientError::Request(e.to_string()))?;
+        let status = response.status().as_u16();
+        let hdrs = collect_headers(&response);
+        let body = response
+            .bytes()
+            .await
+            .map_err(|e| HttpClientError::Request(e.to_string()))?
+            .to_vec();
+        Ok(HttpResponse::new(status, hdrs, body))
+    }
+
+    async fn post(
+        &self,
+        url: &str,
+        headers: &[(&str, &str)],
+        body: Option<&[u8]>,
+    ) -> Result<HttpResponse, HttpClientError> {
+        let mut builder = self.inner.post(url);
+        for &(key, value) in headers {
+            builder = builder.header(key, value);
+        }
+        if let Some(body) = body {
+            builder = builder.body(body.to_vec());
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|e| HttpClientError::Request(e.to_string()))?;
+        let status = response.status().as_u16();
+        let hdrs = collect_headers(&response);
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| HttpClientError::Request(e.to_string()))?
+            .to_vec();
+        Ok(HttpResponse::new(status, hdrs, bytes))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ProcessRunner
+// ---------------------------------------------------------------------------
+
+/// Output from a subprocess.
+#[derive(Debug, Clone)]
+pub struct ProcessOutput {
+    pub status_success: bool,
+    pub status_code: Option<i32>,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+/// Abstraction over async subprocess execution.
+#[async_trait]
+pub trait ProcessRunner: Send + Sync {
+    async fn run(
+        &self,
+        cmd: &str,
+        args: &[&str],
+    ) -> Result<ProcessOutput, ProcessRunnerError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProcessRunnerError {
+    #[error("process execution failed: {0}")]
+    Execution(String),
+}
+
+/// Production implementation using `tokio::process::Command`.
+#[derive(Debug, Default)]
+pub struct TokioProcessRunner;
+
+#[async_trait]
+impl ProcessRunner for TokioProcessRunner {
+    async fn run(
+        &self,
+        cmd: &str,
+        args: &[&str],
+    ) -> Result<ProcessOutput, ProcessRunnerError> {
+        let output = tokio::process::Command::new(cmd)
+            .args(args)
+            .output()
+            .await
+            .map_err(|e| ProcessRunnerError::Execution(e.to_string()))?;
+        Ok(ProcessOutput {
+            status_success: output.status.success(),
+            status_code: output.status.code(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FileSystem
+// ---------------------------------------------------------------------------
+
+/// Abstraction over filesystem operations used by workspace and logging code.
+pub trait FileSystem: Send + Sync {
+    fn create_dir_all(&self, path: &Path) -> std::io::Result<()>;
+    fn exists(&self, path: &Path) -> bool;
+    fn is_dir(&self, path: &Path) -> bool;
+    fn remove_file(&self, path: &Path) -> std::io::Result<()>;
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()>;
+    fn read_to_string(&self, path: &Path) -> std::io::Result<String>;
+    fn write(&self, path: &Path, contents: &[u8]) -> std::io::Result<()>;
+}
+
+/// Production implementation delegating to `std::fs`.
+#[derive(Debug, Default, Clone)]
+pub struct RealFileSystem;
+
+impl FileSystem for RealFileSystem {
+    fn create_dir_all(&self, path: &Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(path)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn is_dir(&self, path: &Path) -> bool {
+        path.is_dir()
+    }
+
+    fn remove_file(&self, path: &Path) -> std::io::Result<()> {
+        std::fs::remove_file(path)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> std::io::Result<()> {
+        std::fs::remove_dir_all(path)
+    }
+
+    fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
+        std::fs::read_to_string(path)
+    }
+
+    fn write(&self, path: &Path, contents: &[u8]) -> std::io::Result<()> {
+        std::fs::write(path, contents)
+    }
+}

--- a/rust/src/tracker/github/adapter.rs
+++ b/rust/src/tracker/github/adapter.rs
@@ -2,11 +2,13 @@ use std::sync::RwLock;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use reqwest::StatusCode;
 use tracing::{info, warn};
 
 use super::client::GitHubClient;
 use crate::config::{resolve_github_token, schema::TrackerConfig};
+use crate::ports::{
+    HttpClient, ProcessRunner, ReqwestHttpClient, TokioProcessRunner,
+};
 use crate::tracker::{Issue, Tracker, TrackerError};
 
 const INITIAL_GRAPHQL_BACKOFF_SECS: u64 = 60;
@@ -16,8 +18,10 @@ const MAX_GRAPHQL_BACKOFF_SECS: u64 = 15 * 60;
 /// refresh at least this often regardless of the tier-1 result.
 const CACHE_TTL_SECS: i64 = 120;
 
-pub struct GitHubAdapter {
-    client: GitHubClient,
+pub struct GitHubAdapter<H: HttpClient = ReqwestHttpClient, P: ProcessRunner = TokioProcessRunner> {
+    client: GitHubClient<H>,
+    http: H,
+    process: P,
     config: TrackerConfig,
     /// Cached project items from the last successful GraphQL fetch.
     project_cache: RwLock<Option<Vec<Issue>>>,
@@ -99,8 +103,26 @@ impl BackoffState {
 
 impl GitHubAdapter {
     pub fn new(config: TrackerConfig) -> Self {
+        let http = ReqwestHttpClient::new();
         Self {
-            client: GitHubClient::new(),
+            client: GitHubClient::with_http(http.clone()),
+            http,
+            process: TokioProcessRunner,
+            config,
+            project_cache: RwLock::new(None),
+            change_etag: RwLock::new(None),
+            graphql_backoff: RwLock::new(BackoffState::new()),
+            last_graphql_fetch: RwLock::new(None),
+        }
+    }
+}
+
+impl<H: HttpClient + Clone, P: ProcessRunner> GitHubAdapter<H, P> {
+    pub fn with_deps(config: TrackerConfig, http: H, process: P) -> Self {
+        Self {
+            client: GitHubClient::with_http(http.clone()),
+            http,
+            process,
             config,
             project_cache: RwLock::new(None),
             change_etag: RwLock::new(None),
@@ -144,11 +166,9 @@ impl GitHubAdapter {
             .map(|items| Self::filter_project_items(items, requested_states))
     }
 
-    fn update_change_etag(&self, response: &reqwest::Response) {
-        if let Some(etag) = response.headers().get("etag") {
-            if let Ok(etag) = etag.to_str() {
-                *self.change_etag.write().unwrap() = Some(etag.to_string());
-            }
+    fn update_change_etag_from_response(&self, response: &crate::ports::HttpResponse) {
+        if let Some(etag) = response.header("etag") {
+            *self.change_etag.write().unwrap() = Some(etag.to_string());
         }
     }
 
@@ -182,44 +202,45 @@ impl GitHubAdapter {
             .await
             .map_err(|_| TrackerError::MissingApiKey)?;
         let url = Self::change_detection_url(&self.config)?;
+        let bearer = format!("Bearer {token}");
 
-        let mut request = reqwest::Client::new()
-            .get(&url)
-            .header("Authorization", format!("Bearer {token}"))
-            .header("Accept", "application/vnd.github+json")
-            .header("User-Agent", "rusty/0.1");
+        let mut headers = vec![
+            ("Authorization", bearer.as_str()),
+            ("Accept", "application/vnd.github+json"),
+            ("User-Agent", "rusty/0.1"),
+        ];
 
-        if let Some(etag) = self.change_etag.read().unwrap().clone() {
-            request = request.header("If-None-Match", etag);
+        let etag_value = self.change_etag.read().unwrap().clone();
+        if let Some(ref etag) = etag_value {
+            headers.push(("If-None-Match", etag.as_str()));
         }
 
-        let response = request
-            .send()
+        let response = self
+            .http
+            .get(&url, &headers)
             .await
             .map_err(|err| TrackerError::ApiRequest(err.to_string()))?;
 
-        match response.status() {
-            StatusCode::NOT_MODIFIED => {
-                self.update_change_etag(&response);
+        match response.status {
+            304 => {
+                self.update_change_etag_from_response(&response);
                 Ok(ChangeCheck::Unchanged)
             }
-            StatusCode::OK => {
-                self.update_change_etag(&response);
+            200 => {
+                self.update_change_etag_from_response(&response);
                 Ok(ChangeCheck::Changed)
             }
-            StatusCode::TOO_MANY_REQUESTS => {
+            429 => {
                 let reset_at = response
-                    .headers()
-                    .get("x-ratelimit-reset")
-                    .and_then(|value| value.to_str().ok())
+                    .header("x-ratelimit-reset")
                     .and_then(|value| value.parse::<i64>().ok())
                     .and_then(|timestamp| DateTime::<Utc>::from_timestamp(timestamp, 0))
                     .unwrap_or_else(Utc::now);
                 Err(TrackerError::RateLimited { reset_at })
             }
             status => {
-                let body = response.text().await.unwrap_or_default();
-                Err(TrackerError::ApiStatus(status.as_u16(), body))
+                let body = response.text();
+                Err(TrackerError::ApiStatus(status, body))
             }
         }
     }
@@ -335,24 +356,28 @@ impl GitHubAdapter {
             .as_deref()
             .ok_or(TrackerError::MissingRepo)?;
         let project_number = self.config.project_number.unwrap_or(0);
+        let number_str = project_number.to_string();
 
-        let output = tokio::process::Command::new("gh")
-            .args([
-                "project",
-                "item-list",
-                &project_number.to_string(),
-                "--owner",
-                owner,
-                "--format",
-                "json",
-                "--limit",
-                "100",
-            ])
-            .output()
+        let output = self
+            .process
+            .run(
+                "gh",
+                &[
+                    "project",
+                    "item-list",
+                    &number_str,
+                    "--owner",
+                    owner,
+                    "--format",
+                    "json",
+                    "--limit",
+                    "100",
+                ],
+            )
             .await
             .map_err(|e| TrackerError::ApiRequest(format!("gh project item-list failed: {e}")))?;
 
-        if !output.status.success() {
+        if !output.status_success {
             let stderr = String::from_utf8_lossy(&output.stderr);
             if Self::is_graphql_rate_limited(&stderr) {
                 return Err(TrackerError::RateLimited {
@@ -360,9 +385,12 @@ impl GitHubAdapter {
                 });
             }
 
+            let status_display = output
+                .status_code
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
             return Err(TrackerError::ApiRequest(format!(
-                "gh project item-list returned {}: {stderr}",
-                output.status
+                "gh project item-list returned {status_display}: {stderr}",
             )));
         }
 
@@ -494,7 +522,7 @@ impl GitHubAdapter {
 }
 
 #[async_trait]
-impl Tracker for GitHubAdapter {
+impl<H: HttpClient + Clone, P: ProcessRunner> Tracker for GitHubAdapter<H, P> {
     async fn fetch_candidate_issues(
         &self,
         config: &TrackerConfig,
@@ -656,7 +684,7 @@ mod tests {
             ..tracker_config()
         };
 
-        let url = GitHubAdapter::change_detection_url(&config).unwrap();
+        let url = <GitHubAdapter>::change_detection_url(&config).unwrap();
 
         assert_eq!(
             url,

--- a/rust/src/tracker/github/client.rs
+++ b/rust/src/tracker/github/client.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use chrono::{DateTime, Utc};
-use reqwest::Client;
 use tracing::{debug, warn};
 
 use crate::config::schema::TrackerConfig;
+use crate::ports::{HttpClient, ReqwestHttpClient};
 use crate::tracker::{Issue, TrackerError};
 
-pub struct GitHubClient {
-    http: Client,
+pub struct GitHubClient<H: HttpClient = ReqwestHttpClient> {
+    http: H,
     etag_cache: RwLock<HashMap<String, String>>,
     /// Cached issue payloads from last successful fetch, keyed by base URL+state.
     /// Used to return previous results on 304 Not Modified responses.
@@ -19,7 +19,17 @@ pub struct GitHubClient {
 impl GitHubClient {
     pub fn new() -> Self {
         Self {
-            http: Client::new(),
+            http: ReqwestHttpClient::new(),
+            etag_cache: RwLock::new(HashMap::new()),
+            response_cache: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl<H: HttpClient> GitHubClient<H> {
+    pub fn with_http(http: H) -> Self {
+        Self {
+            http,
             etag_cache: RwLock::new(HashMap::new()),
             response_cache: RwLock::new(HashMap::new()),
         }
@@ -62,6 +72,7 @@ impl GitHubClient {
         let cache_key = format!("{base_url}?state={state}");
         let mut all_issues = Vec::new();
         let mut page = 1_u32;
+        let bearer = format!("Bearer {token}");
 
         loop {
             let mut url = format!("{base_url}?state={state}&per_page=50&page={page}");
@@ -71,47 +82,42 @@ impl GitHubClient {
 
             debug!(%url, page, "fetching GitHub issues page");
 
-            let mut request = self
-                .http
-                .get(&url)
-                .header("Authorization", format!("Bearer {token}"))
-                .header("Accept", "application/vnd.github+json")
-                .header("User-Agent", "rusty/0.1");
+            let mut headers = vec![
+                ("Authorization", bearer.as_str()),
+                ("Accept", "application/vnd.github+json"),
+                ("User-Agent", "rusty/0.1"),
+            ];
 
-            if let Some(etag) = self.etag_cache.read().unwrap().get(&url).cloned() {
-                request = request.header("If-None-Match", etag);
+            let etag_value = self.etag_cache.read().unwrap().get(&url).cloned();
+            if let Some(ref etag) = etag_value {
+                headers.push(("If-None-Match", etag.as_str()));
             }
 
-            let response = request
-                .send()
+            let response = self
+                .http
+                .get(&url, &headers)
                 .await
                 .map_err(|err| TrackerError::ApiRequest(err.to_string()))?;
-            let status = response.status().as_u16();
+            let status = response.status;
 
-            if let Some(etag) = response.headers().get("etag") {
-                if let Ok(etag_str) = etag.to_str() {
-                    self.etag_cache
-                        .write()
-                        .unwrap()
-                        .insert(url.clone(), etag_str.to_string());
-                }
+            if let Some(etag_str) = response.header("etag") {
+                self.etag_cache
+                    .write()
+                    .unwrap()
+                    .insert(url.clone(), etag_str.to_string());
             }
 
             match status {
                 304 => {
                     debug!(%url, "GitHub API returned 304 Not Modified");
-                    // Return cached response from last successful fetch
                     if let Some(cached) = self.response_cache.read().unwrap().get(&cache_key) {
                         return Ok(cached.clone());
                     }
-                    // No cache available (shouldn't happen, but safe fallback)
                     break;
                 }
                 429 => {
                     let reset_at = response
-                        .headers()
-                        .get("x-ratelimit-reset")
-                        .and_then(|value| value.to_str().ok())
+                        .header("x-ratelimit-reset")
                         .and_then(|value| value.parse::<i64>().ok())
                         .and_then(|timestamp| DateTime::<Utc>::from_timestamp(timestamp, 0))
                         .unwrap_or_else(Utc::now);
@@ -120,14 +126,13 @@ impl GitHubClient {
                 }
                 200 => {}
                 _ => {
-                    let body = response.text().await.unwrap_or_default();
+                    let body = response.text();
                     return Err(TrackerError::ApiStatus(status, body));
                 }
             }
 
             let items: Vec<serde_json::Value> = response
                 .json()
-                .await
                 .map_err(|err| TrackerError::UnknownPayload(err.to_string()))?;
 
             if items.is_empty() {
@@ -170,25 +175,26 @@ impl GitHubClient {
             .trim_end_matches('/');
         let repo_name = Self::repo_name(config);
         let mut issues = Vec::new();
+        let bearer = format!("Bearer {token}");
 
         for &number in numbers {
             let url = format!("{endpoint}/repos/{repo}/issues/{number}");
+            let headers = [
+                ("Authorization", bearer.as_str()),
+                ("Accept", "application/vnd.github+json"),
+                ("User-Agent", "rusty/0.1"),
+            ];
             let response = self
                 .http
-                .get(&url)
-                .header("Authorization", format!("Bearer {token}"))
-                .header("Accept", "application/vnd.github+json")
-                .header("User-Agent", "rusty/0.1")
-                .send()
+                .get(&url, &headers)
                 .await
                 .map_err(|err| TrackerError::ApiRequest(err.to_string()))?;
 
-            let status = response.status().as_u16();
+            let status = response.status;
             match status {
                 200 => {
                     let item: serde_json::Value = response
                         .json()
-                        .await
                         .map_err(|err| TrackerError::UnknownPayload(err.to_string()))?;
                     if let Some(issue) = normalize_github_issue(&item, &repo_name, config) {
                         issues.push(issue);
@@ -196,9 +202,7 @@ impl GitHubClient {
                 }
                 429 => {
                     let reset_at = response
-                        .headers()
-                        .get("x-ratelimit-reset")
-                        .and_then(|value| value.to_str().ok())
+                        .header("x-ratelimit-reset")
                         .and_then(|value| value.parse::<i64>().ok())
                         .and_then(|timestamp| DateTime::<Utc>::from_timestamp(timestamp, 0))
                         .unwrap_or_else(Utc::now);


### PR DESCRIPTION
## Summary

Extract three trait-based abstractions for external dependencies so core modules can be unit tested without network, filesystem, or subprocess access.

### Changes

- **New \src/ports.rs\ module** with three traits and their production implementations:
  - \HttpClient\ (async get/post) → \ReqwestHttpClient\
  - \ProcessRunner\ (async subprocess) → \TokioProcessRunner\
  - \FileSystem\ (sync fs ops) → \RealFileSystem\

- **\GitHubClient<H: HttpClient>\** — parameterized on injectable HTTP client (default: \ReqwestHttpClient\)

- **\GitHubAdapter<H: HttpClient, P: ProcessRunner>\** — parameterized on injectable HTTP client and process runner (defaults to real impls)

- **\esolve_github_token_with()\** — new function accepting injectable \ProcessRunner\, original \esolve_github_token()\ retained as convenience wrapper

- **\ShellExecutor\ trait** — verified existing coverage in \workspace/hooks.rs\ (already fully trait-based with DI)

### Backward Compatibility

All types retain default generic parameters pointing to production implementations. Existing constructors (\GitHubClient::new()\, \GitHubAdapter::new()\) continue to work unchanged.

### Testing

- All 316+ existing tests pass
- \cargo build\ clean
- \cargo clippy\ — no new warnings (pre-existing warnings in unrelated files)

Closes #79